### PR TITLE
Add error handling for corrupt files

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -25,8 +25,11 @@ class TarballEditorProvider implements vscode.CustomReadonlyEditorProvider<Tarba
       enableCommandUris: true,
     };
     return new Promise(async resolve => {
-      const links = (await document.getListing())
-        .map(file => `<a href=${document.getUriFor(file)}>${file}</a>`);
+      const links = await document.getListing()
+        .then(files => files.map(file => `<a href=${document.getUriFor(file)}>${file}</a>`))
+        .catch((err) => {
+          return [`<h1>Error opening file:</h1>\n<em>${err.toString()}</em>`];
+        });
       webviewPanel.webview.html = `
       <!DOCTYPE html>
       <html lang="en">


### PR DESCRIPTION
To test (with the other change that allows `.tar.gz` files to be read), simply rename a `.tar.gz` file to `.tar` and try to read it with this extension